### PR TITLE
Save the CA bundle to a kubernetes secret

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     - cron: 0 1 * * *
   push:
-    branches: [ main ]
+    branches: [ main, kubernetes-secret ]
   pull_request:
     branches: [ main ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ RUN yum -y install epel-release && yum -y update
 
 RUN yum -y install rsync ca-policy-egi-core fetch-crl
 
-RUN curl -LO https://dl.k8s.io/release/v1.29.0/bin/linux/amd64/kubectl
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
-
 RUN chmod go+rx /update-trust-anchors.sh && chmod go+w /etc/grid-security/certificates/ && chmod -R go+wx /etc/pki
 
 ENTRYPOINT ["/update-trust-anchors.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM almalinux:9
 
 COPY EGI-trustanchors.repo /etc/yum.repos.d/
 COPY ./update-trust-anchors.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./update-trust-anchors.sh /
 RUN adduser --uid 12345 randomuser
 RUN yum -y install epel-release && yum -y update
 
-RUN yum -y install rsync ca-policy-egi-core fetch-crl
+RUN yum -y install rsync ca-policy-egi-core fetch-crl kubectl
 
 RUN chmod go+rx /update-trust-anchors.sh && chmod go+w /etc/grid-security/certificates/ && chmod -R go+wx /etc/pki
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ COPY ./update-trust-anchors.sh /
 RUN adduser --uid 12345 randomuser
 RUN yum -y install epel-release && yum -y update
 
-RUN yum -y install rsync ca-policy-egi-core fetch-crl kubectl
+RUN yum -y install rsync ca-policy-egi-core fetch-crl
+
+RUN curl -LO https://dl.k8s.io/release/v1.29.0/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin
 
 RUN chmod go+rx /update-trust-anchors.sh && chmod go+w /etc/grid-security/certificates/ && chmod -R go+wx /etc/pki
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+pipeline {
+
+  agent { label 'docker' }
+  
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+    timeout(time: 3, unit: 'HOURS')
+  }
+  
+  triggers {
+    cron('@daily')
+  }
+  
+  stages {
+    stage('build image') {
+      steps {
+        script {
+          def dockerImage = docker.build("indigoiam/egi-trustanchors:${env.BRANCH_NAME}", "-f ./Dockerfile .")
+          docker.withRegistry('https://index.docker.io/v1/', "docker-cnafsoftwaredevel") {
+            dockerImage.push()
+          }
+        }
+      }
+    }
+  }
+}
+
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,18 @@ pipeline {
       }
     }
   }
+  post {
+    failure {
+      mattermostSend(message: "${env.JOB_NAME} - ${env.BUILD_NUMBER} has failed (<${env.BUILD_URL}|Open>)", color: "danger")
+    }
+    changed {
+      script{
+        if ('SUCCESS'.equals(currentBuild.result)) {
+          mattermostSend(message: "${env.JOB_NAME} - ${env.BUILD_NUMBER} Back to normal (<${env.BUILD_URL}|Open>)", color: "good")
+        }
+      }
+    }
+  }
 }
 
 

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -40,7 +40,16 @@ fi
 
 if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then
   echo "Copying ca bundle to ${CA_BUNDLE_SECRET_TARGET}"
-  kubectl create secret generic ca-secret --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem --dry-run=client -o yaml | kubectl apply -f -
+
+  if kubectl get secret "$CA_BUNDLE_SECRET_TARGET" 2>/dev/null; then
+    kubectl create secret generic "$CA_BUNDLE_SECRET_TARGET" --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem --dry-run=client -o yaml | kubectl re
+place -f -
+    echo "Secret '$CA_BUNDLE_SECRET_TARGET' updated."
+  else
+    kubectl create secret generic "$CA_BUNDLE_SECRET_TARGET" --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem
+    echo "Secret '$CA_BUNDLE_SECRET_TARGET' created."
+  fi
+
 fi
 
 if [ $# -gt 0 ]; then

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -42,8 +42,7 @@ if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then
   echo "Copying ca bundle to ${CA_BUNDLE_SECRET_TARGET}"
 
   if kubectl get secret "$CA_BUNDLE_SECRET_TARGET" 2>/dev/null; then
-    kubectl create secret generic "$CA_BUNDLE_SECRET_TARGET" --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem --dry-run=client -o yaml | kubectl re
-place -f -
+    kubectl create secret generic "$CA_BUNDLE_SECRET_TARGET" --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem --dry-run=client -o yaml | kubectl replace -f -
     echo "Secret '$CA_BUNDLE_SECRET_TARGET' updated."
   else
     kubectl create secret generic "$CA_BUNDLE_SECRET_TARGET" --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -38,6 +38,11 @@ if [ -n "${CA_BUNDLE_TARGET}" ]; then
   rsync -avu -O --no-owner --no-group --no-perms --exclude 'CA/private'  /etc/pki/ ${CA_BUNDLE_TARGET}
 fi
 
+if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then
+  echo "Copying ca bundle to ${CA_BUNDLE_SECRET_TARGET}"
+  kubectl create secret generic ca-secret --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem --dry-run=client -o yaml | kubectl apply -f -
+fi
+
 if [ $# -gt 0 ]; then
   echo "Certificate copy requested to $1"
   rsync -avu -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ $1

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -41,6 +41,11 @@ fi
 if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then
   echo "Copying ca bundle to ${CA_BUNDLE_SECRET_TARGET}"
 
+  if ! command -v kubectl &> /dev/null; then
+    curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+    chmod +x /usr/local/bin/kubectl
+  fi
+
   if kubectl get secret "$CA_BUNDLE_SECRET_TARGET" 2>/dev/null; then
     kubectl create secret generic "$CA_BUNDLE_SECRET_TARGET" --from-file=ca.crt=$DEST/pem/tls-ca-bundle-all.pem --dry-run=client -o yaml | kubectl replace -f -
     echo "Secret '$CA_BUNDLE_SECRET_TARGET' updated."


### PR DESCRIPTION
If the nginx in front of IAM is an ingress controller, the CA bundle must be given to nginx as a kubernetes secret object, but currently, it's just saved to a volume.

If the `CA_BUNDLE_SECRET_TARGET` env variable exists, it saves the CA bundle also as a kubernetes secret with the name `$CA_BUNDLE_SECRET_TARGET`. If this variable doesn't exist, it skips saving as kubernetes secret. So, it's backwards compatible.

We have been using the image from this branch at our kubernetes deployment at CERN for months. So, I think it's well-tested.