### PR TITLE
update-trust-anchors.sh: do not append new trust to existing tls-ca-bundle-client.pem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ volume is mounted (where the container /etc/grid-security/certificates is rsync'
 bundles are kept and where the container /etc/pki is rsync'ed, in particular
 the bundle `tls-ca-bundle-all.pem` that contains the usual system bundle plus the egi trust-anchors
 - `CA_BUNDLE_SECRET_TARGET` (default unset): an optional kubernetes secret including tls-ca-bundle-all.pem
-
+- `REMOVE_OBSOLETE_FILES_FROM_TARGET` (default: 0): if 1, remove files that are no longer present in the source
+from `CA_BUNDLE_TARGET` and `TRUST_ANCHORS_TARGET`.
 
 ## Compose file
 

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -62,7 +62,7 @@ if [ -n "${CA_BUNDLE_TARGET}" ]; then
 fi
 
 if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then
-  echo "Copying ca bundle to ${CA_BUNDLE_SECRET_TARGET}"
+  echo "Copying CA bundle to ${CA_BUNDLE_SECRET_TARGET}"
 
   if ! command -v kubectl &> /dev/null; then
     curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -39,7 +39,9 @@ else
   cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem >> $DEST/pem/tls-ca-bundle-all.pem
 fi
 
-TRUST_ANCHORS_TARGET=${TRUST_ANCHORS_TARGET:=}
+# For backward compatibility, allow to define TRUST_ANCHORS_TARGET as a script parameter rather
+# than defining the variable
+TRUST_ANCHORS_TARGET=${TRUST_ANCHORS_TARGET:=$1}
 CA_BUNDLE_TARGET=${CA_BUNDLE_TARGET:=}
 
 if [ ${REMOVE_OBSOLETE_FILES_FROM_TARGET} -eq 1 ]

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -ex
 
-# Variable to restore the old buggy behaviour resulting in duplicating entries in the
-# new CA bundle.
-# FIXME: remove once everybody agreed that previous behaviour was a bug...
-CA_BUNDLE_APPEND_NEW_TRUST=${CA_BUNDLE_APPEND_NEW_TRUST:=0}
-
 # Variable to remove from CA_BUNDLE_TARGET files no longer existing in /etc/pki
 # Disabled by default (backward compatibility)
 REMOVE_OBSOLETE_FILES_FROM_TARGET=${REMOVE_OBSOLETE_FILES_FROM_TARGET:-0}
@@ -32,12 +27,7 @@ update-ca-trust extract
 ## which looks like a bug: readd it after extracting the new trust.
 DEST=/etc/pki/ca-trust/extracted
 /usr/bin/p11-kit extract --comment --format=pem-bundle --filter=ca-anchors --overwrite --purpose client-auth $DEST/pem/tls-ca-bundle-client.pem
-if [ ${CA_BUNDLE_APPEND_NEW_TRUST} -eq 0 ]
-then
-  cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem > $DEST/pem/tls-ca-bundle-all.pem
-else
-  cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem >> $DEST/pem/tls-ca-bundle-all.pem
-fi
+cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem > $DEST/pem/tls-ca-bundle-all.pem
 
 # For backward compatibility, allow to define TRUST_ANCHORS_TARGET as a script parameter rather
 # than defining the variable

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -6,7 +6,11 @@ set -ex
 # FIXME: remove once everybody agreed that previous behaviour was a bug...
 CA_BUNDLE_APPEND_NEW_TRUST=${CA_BUNDLE_APPEND_NEW_TRUST:=0}
 
+# Variable to remove from CA_BUNDLE_TARGET files no longer existing in /etc/pki
+# Disabled by default (backward compatibility)
+REMOVE_OBSOLETE_FILES_FROM_TARGET=${REMOVE_OBSOLETE_FILES_FROM_TARGET:-0}
 
+# fetch-crl timeout
 FETCH_CRL_TIMEOUT_SECS=${FETCH_CRL_TIMEOUT_SECS:-5}
 
 if [[ -z "${FORCE_TRUST_ANCHORS_UPDATE}" ]]; then
@@ -38,14 +42,23 @@ fi
 TRUST_ANCHORS_TARGET=${TRUST_ANCHORS_TARGET:=}
 CA_BUNDLE_TARGET=${CA_BUNDLE_TARGET:=}
 
+if [ ${REMOVE_OBSOLETE_FILES_FROM_TARGET} -eq 1 ]
+then
+  delete_options='--delete'
+  delete_msg='and removing obsolete file from it'
+else
+  delete_options=''
+  delete_msg=''
+fi
+
 if [ -n "${TRUST_ANCHORS_TARGET}" ]; then
-  echo "Copying trust anchors to ${TRUST_ANCHORS_TARGET}"
-  rsync -avu -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ ${TRUST_ANCHORS_TARGET}
+  echo "Copying trust anchors to ${TRUST_ANCHORS_TARGET} ${delete_msg}"
+  rsync -avu ${delete_options} -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ ${TRUST_ANCHORS_TARGET}
 fi
 
 if [ -n "${CA_BUNDLE_TARGET}" ]; then
-  echo "Copying ca bundle to ${CA_BUNDLE_TARGET}"
-  rsync -avu -O --no-owner --no-group --no-perms --exclude 'CA/private'  /etc/pki/ ${CA_BUNDLE_TARGET}
+  echo "Copying CA bundle to ${CA_BUNDLE_TARGET} ${delete_msg}"
+  rsync -avu ${delete_options} -O --no-owner --no-group --no-perms --exclude 'CA/private'  /etc/pki/ ${CA_BUNDLE_TARGET}
 fi
 
 if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -ex
 
-# Variable to remove from CA_BUNDLE_TARGET files no longer existing in /etc/pki
+# Variable to remove from the targets the CA files no longer existing in /etc/pki
 # Disabled by default (backward compatibility)
-REMOVE_OBSOLETE_FILES_FROM_TARGET=${REMOVE_OBSOLETE_FILES_FROM_TARGET:-0}
+REMOVE_OBSOLETE_FILES_FROM_TARGET=${REMOVE_OBSOLETE_FILES_FROM_TARGET:=}
 
 # fetch-crl timeout
 FETCH_CRL_TIMEOUT_SECS=${FETCH_CRL_TIMEOUT_SECS:-5}

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -34,8 +34,7 @@ cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem > $DEST/pem/t
 TRUST_ANCHORS_TARGET=${TRUST_ANCHORS_TARGET:=$1}
 CA_BUNDLE_TARGET=${CA_BUNDLE_TARGET:=}
 
-if [ ${REMOVE_OBSOLETE_FILES_FROM_TARGET} -eq 1 ]
-then
+if [ ${REMOVE_OBSOLETE_FILES_FROM_TARGET} -eq 1 ]; then
   delete_options='--delete'
   delete_msg='and removing obsolete file from it'
 else

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -23,8 +23,8 @@ done
 
 update-ca-trust extract
 
-## Updated CA trust does not include trust anchors that can sign client-auth certs,
-## which looks like a bug: readd it after extracting the new trust.
+## update-ca-trust does not include trust anchors that can sign client-auth certs,
+## which looks like a bug: re-add them after extracting the new trust.
 DEST=/etc/pki/ca-trust/extracted
 /usr/bin/p11-kit extract --comment --format=pem-bundle --filter=ca-anchors --overwrite --purpose client-auth $DEST/pem/tls-ca-bundle-client.pem
 cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem > $DEST/pem/tls-ca-bundle-all.pem

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -29,9 +29,7 @@ DEST=/etc/pki/ca-trust/extracted
 /usr/bin/p11-kit extract --comment --format=pem-bundle --filter=ca-anchors --overwrite --purpose client-auth $DEST/pem/tls-ca-bundle-client.pem
 cat $DEST/pem/tls-ca-bundle.pem $DEST/pem/tls-ca-bundle-client.pem > $DEST/pem/tls-ca-bundle-all.pem
 
-# For backward compatibility, allow to define TRUST_ANCHORS_TARGET as a script parameter rather
-# than defining the variable
-TRUST_ANCHORS_TARGET=${TRUST_ANCHORS_TARGET:=$1}
+TRUST_ANCHORS_TARGET=${TRUST_ANCHORS_TARGET:=}
 CA_BUNDLE_TARGET=${CA_BUNDLE_TARGET:=}
 
 if [ ${REMOVE_OBSOLETE_FILES_FROM_TARGET} -eq 1 ]; then

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -94,5 +94,5 @@ fi
 
 if [ $# -gt 0 ]; then
   echo "Copying trust anchors to $1 ${delete_msg}"
-  rsync -avu -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ $1
+  rsync -avu ${delete_options} -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ $1
 fi

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -93,6 +93,6 @@ if [ -n "${JAVA_BUNDLE_TARGET}" ]; then
 fi
 
 if [ $# -gt 0 ]; then
-  echo "Certificate copy requested to $1"
+  echo "Copying trust anchors to $1 ${delete_msg}"
   rsync -avu -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ $1
 fi

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -37,9 +37,6 @@ CA_BUNDLE_TARGET=${CA_BUNDLE_TARGET:=}
 if [ ${REMOVE_OBSOLETE_FILES_FROM_TARGET} -eq 1 ]; then
   delete_options='--delete'
   delete_msg='and removing obsolete file from it'
-else
-  delete_options=''
-  delete_msg=''
 fi
 
 if [ -n "${TRUST_ANCHORS_TARGET}" ]; then


### PR DESCRIPTION
- Previous behavior considered buggy: a lot of entries duplicated, bundle unnecessarily big
  - CERN confirmed in Mattermost it was not relying on this buggy feature
