### PR TITLE
Allow to manage/update Java keystore cacerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./update-trust-anchors.sh /
 RUN adduser --uid 12345 randomuser
 RUN yum -y install epel-release && yum -y update
 
-RUN yum -y install rsync ca-policy-egi-core fetch-crl
+RUN yum -y install rsync ca-policy-egi-core fetch-crl java-openjdk-headless
 
 RUN chmod go+rx /update-trust-anchors.sh && chmod go+w /etc/grid-security/certificates/ && chmod -R go+wx /etc/pki
 

--- a/update-trust-anchors.sh
+++ b/update-trust-anchors.sh
@@ -56,6 +56,33 @@ if [ -n "${CA_BUNDLE_SECRET_TARGET}" ]; then
 
 fi
 
+if [ -n "${JAVA_BUNDLE_TARGET}" ]; then
+  echo "Updating Java cacerts keystore..."
+  if [ -d "${JAVA_BUNDLE_TARGET}" ]; then
+    keystore_target="${JAVA_BUNDLE_TARGET}/cacerts"
+  else
+    keystore_target="${JAVA_BUNDLE_TARGET}"
+  fi
+  java_rpm_pattern=openjdk-headless
+  java_rpm=$(rpm -qa | grep ${java_rpm_pattern} | head -1)
+  if [ -n "${java_rpm}" ]; then
+    cacerts_file=$(rpm -q ${java_rpm} -l | grep cacerts)
+    cp ${cacerts_file} ${keystore_target}
+    for c in /etc/grid-security/certificates/*.pem; do
+      # Prefix alias with IGTF- to prevent any collision with an existing alias in cacerts
+      ca_alias=IGTF-$(basename ${c} .pem)
+      echo ca_alias=$ca_alias
+      keytool -importcert -trustcacerts -noprompt \
+	      -alias ${ca_alias} \
+  	      -keystore ${keystore_target} \
+  	      -file ${c} -storepass changeit
+    done
+  else
+    echo "Java RPM (${java_rpm_pattern}) not installed: cannot update Java cacerts keystore"
+    exit 1
+  fi
+fi
+
 if [ $# -gt 0 ]; then
   echo "Certificate copy requested to $1"
   rsync -avu -O --no-owner --no-group --no-perms /etc/grid-security/certificates/ $1


### PR DESCRIPTION
This PR allows to update the default Java `cacerts` keystore (equivalent of OS CA bundle) with the IGTF-blessed CAs, in the same way it is done for OS CA bundle. To enable the management of `cacerts`, define `JAVA_BUNDLE_TARGET` as the directory where to put the updated version (typically a mount point with write access).

This updated Java bundle that includes the IGTF CAs is needed  for retrieving SAML metadata from a https source that uses a certificate issued by an IGTF CA, as the code used is from the SAML module that uses the Java CA bundle. See the discussion at the end of this PR.